### PR TITLE
Address issue #33, check compatibility and updata CI

### DIFF
--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -25,53 +25,62 @@ jobs:
           - macOS-latest
           - ubuntu-latest
           - windows-latest
-        include:
-        - os: ubuntu-latest
-          path: ~/.cache/pip
-        - os: macos-latest
-          path: ~/Library/Caches/pip
-        - os: windows-latest
-          path: ~\AppData\Local\pip\Cache
+        exclude:
+          - os: macOS-latest
+            python-version: "3.9"
     defaults:
       run:
         shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      with:
-        path: ${{ matrix.path }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        auto-activate-base: true
-        auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
-        activate-environment: test
-    - name: Install required packages 
-      run: |
-        conda config --add channels conda-forge 
-        # conda install -yq conda-build jinja2 conda-verify
-        conda install -yq zlib
-        conda install h5py
-        python -m pip install --upgrade pip
-        # conda update conda-build
-    # - name: Conda build    
-      # run: |
-        # conda build --quiet devtools/conda-recipe 
-    - name: Pip install
-      run: |
-        python -m pip install .
-    - name: Test with pytest
-      run: |
-        # conda install -yq -c ${CONDA_PREFIX}/conda-bld/ msmbuilder2022
-        conda install -yq numdifftools hmmlearn
-        pip install pytest
-        mkdir ../../pkgs
-        cp -r msmbuilder/tests ../../pkgs
-        cd ../../pkgs
-        python tests/data_init.py
-        pytest tests/ -v
+      - uses: actions/checkout@v4
+      - name: Set pip cache path
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "PIP_CACHE=~/.cache/pip" >> $GITHUB_ENV
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "PIP_CACHE=~/Library/Caches/pip" >> $GITHUB_ENV
+          else
+            echo "PIP_CACHE=$LOCALAPPDATA\\pip\\Cache" >> $GITHUB_ENV
+          fi
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.PIP_CACHE }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: true
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      - name: Install required packages 
+        run: |
+          conda config --add channels conda-forge 
+          # conda install -yq conda-build jinja2 conda-verify
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            conda install -yq zlib libstdcxx-ng h5py 
+          else
+            conda install -yq zlib h5py 
+          fi
+          python -m pip install --upgrade pip
+          # conda update conda-build
+      # - name: Conda build    
+        # run: |
+          # conda build --quiet devtools/conda-recipe 
+      - name: Pip install
+        run: |
+          python -m pip install .
+      - name: Test with pytest
+        run: |
+          # conda install -yq -c ${CONDA_PREFIX}/conda-bld/ msmbuilder2022
+          # conda install -yq numdifftools hmmlearn
+          pip install numdifftools hmmlearn statsmodels
+          pip install pytest
+          mkdir ../../pkgs
+          cp -r msmbuilder/tests ../../pkgs
+          cd ../../pkgs
+          python tests/data_init.py
+          pytest tests/ -v
         

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,8 +49,11 @@ jobs:
         run: |
           conda config --add channels conda-forge 
           # conda install -yq conda-build jinja2 conda-verify
-          conda install -yq zlib
-          conda install h5py
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            conda install -yq zlib libstdcxx-ng h5py 
+          else
+            conda install -yq zlib h5py 
+          fi
           python -m pip install --upgrade pip
       # Used to host cibuildwheel
       - name: Pip install and build wheels
@@ -63,7 +66,8 @@ jobs:
         run: |
           pip install wheelhouse/msmbuilder2022*.whl
           
-          conda install -yq numdifftools hmmlearn
+          # conda install -yq numdifftools hmmlearn
+          pip install numdifftools hmmlearn statsmodels
           pip install pytest
           pip install pytest-cov
           mkdir ../../pkgs

--- a/msmbuilder/cluster/src/kmedoids.cc
+++ b/msmbuilder/cluster/src/kmedoids.cc
@@ -359,7 +359,7 @@ The cluster number to which an element was assigned.
         /* j = binomial(n, p); */
         args = Py_BuildValue("(dd)", static_cast<double>(n), p);
         result = PyObject_Call(binomial, args, NULL);
-        j = PyInt_AsLong(result);
+        j = PyLong_AsLong(result);
         Py_DECREF(args);
         Py_DECREF(result);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools", 
         "wheel", 
         "Cython~=0.29.36",
-        "numpy",
+        "numpy<=1.26",
         "mdtraj",
         #"mdtraj @ https://files.pythonhosted.org/packages/88/12/ecbe28c87bc3df8c4880cc742923a6f40633ca076c8f44b03533dfce0b66/mdtraj-1.9.9-cp39-cp39-macosx_10_9_x86_64.whl",
         ]

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ setup(name='msmbuilder2022',
                          ],
       },
       install_requires=[
-          'numpy',
+          'numpy<=1.26',
           'mdtraj',
           'scikit-learn',
           'pandas',


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

1) Address issue by replacing PyInt_AsLong with PyLong_AsLong.
2) Pip 25.1.1 and NumPy v2 may cause compatibility issues. Their versions are currently constrained to avoid build/install/test failures. In the future release, may need to drop Python 3.9 support before addressing these issues. 